### PR TITLE
Enable convergence tester for early stopping.

### DIFF
--- a/python-package/xgboost/automl_core.py
+++ b/python-package/xgboost/automl_core.py
@@ -209,6 +209,14 @@ NUM_TREE_LOWER_BOUND = 0
 DEFAULT_METRIC = {'binary': 'auc', 'multi': 'merror', 'reg': 'rmse', 'rank': 'ndcg',\
                   'survival': 'cox-nloglik'}
 
+def get_optimization_direction(params):
+    maximize_score = False
+    metric = params['eval_metric']
+    if any(metric.startswith(x) for x in MAXIMIZE_METRICS):
+        maximize_score = True
+
+    return maximize_score
+
 def xgb_parameter_checker(params, num_round, num_class=None, skip_list=[]):
     """
     XGBoost hyper-parameter checker.
@@ -324,11 +332,7 @@ def xgb_parameter_checker(params, num_round, num_class=None, skip_list=[]):
             warnings.warn(param_invalid_value_info('eval_metric', DEFAULT_METRIC[objective_type]))
             params['eval_metric'] = DEFAULT_METRIC[objective_type]
 
-    maximize_score = False
-    metric = params['eval_metric']
-    if any(metric.startswith(x) for x in MAXIMIZE_METRICS):
-        maximize_score = True
-
+    maximize_score = get_optimization_direction(params)
     params['maximize_eval_metric'] = str(maximize_score)
 
     return params

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -8,7 +8,7 @@ import warnings
 import numpy as np
 from .core import Booster, STRING_TYPES, XGBoostError, CallbackEnv, EarlyStopException
 from .compat import (SKLEARN_INSTALLED, XGBStratifiedKFold)
-from .automl_core import ConvergenceTester, xgb_parameter_checker
+from .automl_core import ConvergenceTester, xgb_parameter_checker, get_optimization_direction
 from . import rabit
 from . import callback
 
@@ -211,7 +211,7 @@ def train(params, dtrain, num_boost_round=10, evals=(), obj=None, feval=None,
 
     if check_params:
         params = xgb_parameter_checker(params, num_boost_round)
-    maximize=params['maximize_eval_metric'].lower() == 'true'
+    maximize = get_optimization_direction(params)
 
     # Most of legacy advanced options becomes callbacks
     if isinstance(verbose_eval, bool) and verbose_eval:


### PR DESCRIPTION
1. Enable convergence tester for early stopping.
2. Get rid of the need to specify optimization direction in convergence tester.

@sperlingxx 