### PR TITLE
Enable max running time.

### DIFF
--- a/python-package/xgboost/automl_core.py
+++ b/python-package/xgboost/automl_core.py
@@ -232,7 +232,8 @@ def get_eval_metric(params):
                         raise ParamError("A number required after '{}'".format(metric_to_check))
                     checked = True
             if not checked:
-                objective_type = objective.split(':')[0]
+                check_objective(params)
+                objective_type = params['objective'].split(':')[0]
                 eval_metric = DEFAULT_METRIC[objective_type]
         return eval_metric
     else:

--- a/python-package/xgboost/callback.py
+++ b/python-package/xgboost/callback.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import
 from . import rabit
 from .core import EarlyStopException
 from .automl_core import ConvergenceTester
+from datetime import datetime
 
 def _get_callback_context(env):
     """return whether the current callback context is cv or train"""
@@ -316,6 +317,83 @@ def convergence_test(cc, maximize=False, verbose=True):
             best_msg = state['best_msg']
             if verbose and env.rank == 0:
                 msg = "Stopping. Best iteration:\n{}\n\n"
+                rabit.tracker_print(msg.format(best_msg))
+            raise EarlyStopException(best_iteration)
+
+    callback.early_stop = True
+    return callback
+
+def max_runing_time_in_minutes(max_running_time_in_minutes, maximize=False, verbose=True):
+    """Create a callback that activates timer.
+
+    Parameters
+    ----------
+    max_running_time_in_minutes : float
+       The maximum running time in minutes.
+
+    maximize : bool
+        Whether to maximize evaluation metric.
+
+    verbose : optional, bool
+        Whether to print message.
+
+    Returns
+    -------
+    callback : function
+        The requested callback function.
+    """
+    state = {}
+
+    def init(env):
+        """internal function"""
+        bst = env.model
+
+        if len(env.evaluation_result_list) == 0:
+            raise ValueError('To enable max_running_time_in_minutes, you need at least one set in evals.')
+        if len(env.evaluation_result_list) > 1 and verbose:
+            msg = ("Multiple eval metrics have been passed: "
+                   "'{0}' will be used for model selection.\n\n")
+            rabit.tracker_print(msg.format(env.evaluation_result_list[-1][0]))
+
+        ct = ConvergenceTester.parse("-1")
+        ct.reset(maximize)
+        state['ct'] = ct
+
+        state['start_time'] = datetime.now()
+
+        if verbose and env.rank == 0:
+            msg = "Training will terminate in approximately {0} mins.\n".format(max_running_time_in_minutes)
+            rabit.tracker_print(msg.format())
+
+    def callback(env):
+        """internal function"""
+        score = env.evaluation_result_list[-1][1]
+        if 'ct' not in state:
+            init(env)
+        ct = state['ct']
+        best_score = ct.get_best_so_far()
+        best_iteration = ct.get_best_idx() + 1
+        maximize_score = ct.is_maximize()
+        ct.add(score)
+        if (maximize_score and score > best_score) or \
+            (not maximize_score and score < best_score):
+            msg = '[%d]\t%s' % (
+                env.iteration,
+                '\t'.join([_fmt_metric(x) for x in env.evaluation_result_list]))
+            state['best_msg'] = msg
+            state['best_score'] = score
+            state['best_iteration'] = env.iteration
+            # save the property to attributes, so they will occur in checkpoint.
+            if env.model is not None:
+                env.model.set_attr(best_score=str(state['best_score']),
+                                   best_iteration=str(state['best_iteration']),
+                                   best_msg=state['best_msg'])
+
+        elapsed_time_in_mins = (datetime.now() - state['start_time']).seconds / 60.0
+        if elapsed_time_in_mins > max_running_time_in_minutes:
+            best_msg = state['best_msg']
+            if verbose:
+                msg = "Exceeds maximum running time. Best iteration:\n{}\n\n"
                 rabit.tracker_print(msg.format(best_msg))
             raise EarlyStopException(best_iteration)
 

--- a/python-package/xgboost/callback.py
+++ b/python-package/xgboost/callback.py
@@ -359,7 +359,8 @@ def max_runing_time_in_minutes(max_running_time_in_minutes, maximize=False, verb
         ct.reset(maximize)
         state['ct'] = ct
 
-        state['start_time'] = datetime.now()
+        if env.rank == 0:
+            state['start_time'] = datetime.now()
 
         if verbose and env.rank == 0:
             msg = "Training will terminate in approximately {0} mins.\n".format(max_running_time_in_minutes)
@@ -389,13 +390,14 @@ def max_runing_time_in_minutes(max_running_time_in_minutes, maximize=False, verb
                                    best_iteration=str(state['best_iteration']),
                                    best_msg=state['best_msg'])
 
-        elapsed_time_in_mins = (datetime.now() - state['start_time']).seconds / 60.0
-        if elapsed_time_in_mins > max_running_time_in_minutes:
-            best_msg = state['best_msg']
-            if verbose:
-                msg = "Exceeds maximum running time. Best iteration:\n{}\n\n"
-                rabit.tracker_print(msg.format(best_msg))
-            raise EarlyStopException(best_iteration)
+        if env.rank == 0:
+            elapsed_time_in_mins = (datetime.now() - state['start_time']).seconds / 60.0
+            if elapsed_time_in_mins > max_running_time_in_minutes:
+                best_msg = state['best_msg']
+                if verbose:
+                    msg = "Exceeds maximum running time. Best iteration:\n{}\n\n"
+                    rabit.tracker_print(msg.format(best_msg))
+                raise EarlyStopException(best_iteration)
 
-    callback.early_stop = True
+            callback.early_stop = True
     return callback

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -385,6 +385,11 @@ def train(params, dtrain, num_boost_round=10, evals=(), obj=None, feval=None,
                                                    maximize=op_direction,
                                                    verbose=bool(verbose_eval)))
 
+    if isinstance(params, dict) and params.get('max_running_time_in_minutes') is not None:
+        callbacks.append(callback.max_runing_time_in_minutes(float(params.get('max_running_time_in_minutes')),
+                                                             maximize=op_direction,
+                                                             verbose=bool(verbose_eval)))
+
     if evals_result is not None:
         callbacks.append(callback.record_evaluation(evals_result))
 

--- a/tests/python/test_automl_core.py
+++ b/tests/python/test_automl_core.py
@@ -94,8 +94,8 @@ class TestAutomlCore(unittest.TestCase):
         param = {'silent': 1, 'objective': 'binary:logistic', 'eval_metric': 'auc', 'eta': 0.01, \
                  'max_depth': 3, 'max_running_time_in_minutes': 0}
         watchlist = [(dtrain, 'train'), (dtest, 'eval')]
-        best_model = xgb.train(param, dtrain, 500, watchlist)
-        self.assertTrue(int(best_model.attr('best_iteration')) < 450)
+        best_model = xgb.train(param, dtrain, 5000, watchlist)
+        self.assertTrue(int(best_model.attr('best_iteration')) < 4500)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/python/test_automl_core.py
+++ b/tests/python/test_automl_core.py
@@ -95,7 +95,7 @@ class TestAutomlCore(unittest.TestCase):
                  'max_depth': 3, 'max_running_time_in_minutes': 0}
         watchlist = [(dtrain, 'train'), (dtest, 'eval')]
         best_model = xgb.train(param, dtrain, 500, watchlist)
-        self.assertTrue(float(best_model.attr('best_score')) == 1.0)
+        self.assertTrue(int(best_model.attr('best_iteration')) < 500)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/python/test_automl_core.py
+++ b/tests/python/test_automl_core.py
@@ -95,7 +95,7 @@ class TestAutomlCore(unittest.TestCase):
                  'max_depth': 3, 'max_running_time_in_minutes': 0}
         watchlist = [(dtrain, 'train'), (dtest, 'eval')]
         best_model = xgb.train(param, dtrain, 500, watchlist)
-        self.assertTrue(int(best_model.attr('best_iteration')) < 500)
+        self.assertTrue(int(best_model.attr('best_iteration')) < 450)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/python/test_automl_core.py
+++ b/tests/python/test_automl_core.py
@@ -84,5 +84,18 @@ class TestAutomlCore(unittest.TestCase):
         best_model = xgb.auto_train(param, dtrain, 10, watchlist)
         self.assertTrue(float(best_model.attr('best_score')) == 1.0)
 
+    def test_xgboost_max_running_time(self):
+        """
+        A test for auto xgboost when max running time is specified
+        """
+        dir_path = os.path.dirname(os.path.realpath(__file__))
+        dtrain = xgb.DMatrix(dir_path + '/../../demo/data/agaricus.txt.train')
+        dtest = xgb.DMatrix(dir_path + '/../../demo/data/agaricus.txt.test')
+        param = {'silent': 1, 'objective': 'binary:logistic', 'eval_metric': 'auc', 'eta': 0.01, \
+                 'max_depth': 3, 'max_running_time_in_minutes': 0}
+        watchlist = [(dtrain, 'train'), (dtest, 'eval')]
+        best_model = xgb.train(param, dtrain, 500, watchlist)
+        self.assertTrue(float(best_model.attr('best_score')) == 1.0)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Enable `max_running_time_in_minutes` parameter. Training will terminate once exceeding user-defined time limits and it will return the best-so-far model based on eval metric.

@sperlingxx 